### PR TITLE
Readme fix - missing comma in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ grunt.initConfig({
       options: {
         spreadsheetId: '1I5SeO5P621T4J6AoE-xz_NmZTblAJFqGw7fWI2Fw82A',
         ignoreColumns: ['annotations'] // optional
-      }
+      },
       dest: 'translations/'
     }
   }


### PR DESCRIPTION
Pasting this example otherwise throws an error

```
>> SyntaxError: Unexpected identifier
```